### PR TITLE
Improved caching, added event whitelist filters, and bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 # latest
 
-- Fixed issue with `lib/decoders.js` that prevented use of the `initdata` flag
+- Fixed issue with `lib/decoders.js` that prevented use of the `initdata` flag.
+
+# 0.3.1 - 2016-03-24
+
+- Fixed issue with bitwise operators on numbers above 32 bits.
+
+# 0.3.0 - 2016-03-21
+
+- Changed dependencies
+- Uses normalized paths
+- Made output more orderly
+- Fixed typos and failure tests
 
 # 0.2.2 - 2016-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added ability to whitelist game, message, and tracker events based on key-value matches
 - Improved archive caching and added a boolean argument to `.open` that controls whether a cached version should be loaded (if possible).
 - Fixed issue with `header` always being archived under `protocol29406` instead of the proper build.
+- Oldest build tested is build `44256`.
 
 # 0.3.2 - 2017-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # latest
 
+- Added ability to whitelist game, message, and tracker events based on key-value matches
+- Improved archive caching and added a boolean argument to `.open` that controls whether a cached version should be loaded (if possible).
+- Fixed issue with `header` always being archived under `protocol29406` instead of the proper build.
+
+# 0.3.2 - 2017-06-22
+
 - Fixed issue with `lib/decoders.js` that prevented use of the `initdata` flag.
 
 # 0.3.1 - 2016-03-24

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Currently heroprotocol can decode these structures and events:
 
 heroprotocol can be used as a base-build-specific library to decode binary blobs, or it can be run as a standalone tool to pretty print information from supported replay files.
 
+The latest version of this library has been tested and passed with builds 44256 and higher of HoTS replays. Although it is unlikely that you should encounter any issues for older versions, no testing has been done for any replays older than 44256.
+
 Note that heroprotocol does not expose game balance information or provide any kind of high level analysis of replays; it's meant
 to be just the first tool in the chain for your data mining application.
 

--- a/index.js
+++ b/index.js
@@ -40,49 +40,55 @@ const parseStrings = function parseStrings(data) {
 
 let lastUsed;
 
-exports.open = function (file) {
+exports.open = function (file, noCache) {
   let archive, header;
 
-  // TODO - should we check if the user is trying to open the lastUsed file
-  // and return the cache or assume they know what they're doing? Need usecase.
+  if (!lastUsed || !(lastUsed instanceof MPQArchive) || file !== lastUsed.filename || noCache) {
 
-  if (typeof file === 'string') {
-    try {
-      if (!path.isAbsolute(file)) {
-        file = path.join(process.cwd(), file);
+    if (typeof file === 'string') {
+      try {
+        if (!path.isAbsolute(file)) {
+          file = path.join(process.cwd(), file);
+        }
+        archive = new MPQArchive(file);
+        archive.filename = file;
+      } catch (err) {
+        archive = err;
       }
-      archive = new MPQArchive(file);
-      archive.filename = file;
-    } catch (err) {
-      archive = err;
+    } else if (file instanceof MPQArchive) {
+      // TODO - need to check what happens when instanciating an MPQArchive with
+      // invalid path and setup an error accordingly
+      archive = file;
+    } else {
+      archive = new Error('Unsupported parameter: ${file}');
     }
-  } else if (file instanceof MPQArchive) {
-    // TODO - need to check what happens when instanciating an MPQArchive with
-    // invalid path and setup an error accordingly
-    archive = file;
+
+    if (archive instanceof Error) return archive;
+    lastUsed = archive;
+
+    // parse header
+    archive.data = {};
+    header = archive.data[HEADER] = parseStrings(protocol29406.decodeReplayHeader(archive.header.userDataHeader.content));
+    // The header's baseBuild determines which protocol to use
+    archive.baseBuild = header.m_version.m_baseBuild;
+
+    try {
+      archive.protocol = require(`./lib/protocol${archive.baseBuild}`);
+    } catch (err) {
+      archive.error = err;
+    }
+
+    // set header to proper protocol
+    archive.data[HEADER] = parseStrings(archive.protocol.decodeReplayHeader(archive.header.userDataHeader.content));
+
+    archive.get = function (file) {
+      return exports.get(file, archive);
+    };
+
   } else {
-    archive = new Error('Unsupported parameter: ${file}');
+    // load archive from cache
+    archive = lastUsed;
   }
-
-  if (archive instanceof Error) return archive;
-  lastUsed = archive;
-
-  // parse header
-  archive.data = {};
-  header = archive.data[HEADER] = parseStrings(protocol29406.decodeReplayHeader(archive.header.userDataHeader.content));
-  // The header's baseBuild determines which protocol to use
-  archive.baseBuild = header.m_version.m_baseBuild;
-
-  try {
-    archive.protocol = require(`./lib/protocol${archive.baseBuild}`);
-  } catch (err) {
-    archive.error = err;
-  }
-
-  archive.get = function (file) {
-    return exports.get(file, archive);
-  };
-
 
   return archive;
 };
@@ -90,11 +96,7 @@ exports.open = function (file) {
 // returns the content of a file in a replay archive
 exports.get = function (archiveFile, archive) {
   let data;
-  if (!lastUsed || !(archive instanceof MPQArchive) || archive !== lastUsed.filename) {
-    archive = exports.open(archive);
-  } else {
-    lastUsed = archive;
-  }
+  archive = exports.open(archive);
 
   if (archive instanceof Error) {
     return data;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroprotocol",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Javascript port of the heroprotocol Python library to decode Heroes of the Storm replay protocols.",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroprotocol",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Javascript port of the heroprotocol Python library to decode Heroes of the Storm replay protocols.",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroprotocol",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Javascript port of the heroprotocol Python library to decode Heroes of the Storm replay protocols.",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
- Added ability to whitelist game, message, and tracker events based on key-value matches
- Improved archive caching and added a boolean argument to `.open` that controls whether a cached version should be loaded (if possible).
- Fixed issue with `header` always being archived under `protocol29406` instead of the proper build.
