### PR TITLE
Use forked mpyq.js library to fix a major bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "dependencies": {
     "download-github-repo": "^0.1.3",
+    "empeeku": "^1.0.2",
     "fs-extra": "^0.26.7",
     "long": "^3.0.3",
-    "mpyqjs": "^1.0.1",
     "yargs": "^3.32.0"
   },
   "repository": {
@@ -24,8 +24,8 @@
     "mpq"
   ],
   "author": {
-      "name": "Justin J. Novack",
-      "email": "jnovack@gmail.com"
+    "name": "Justin J. Novack",
+    "email": "jnovack@gmail.com"
   },
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroprotocol",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "description": "Javascript port of the heroprotocol Python library to decode Heroes of the Storm replay protocols.",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Hi there!

I fixed a bug with the mpyq.js library that prevented MPQ file multi sector part reads. This was happening with certain HotS replay files (specifically with the tracker events section of some replay files). 

Unfortunately, it appears the maintainer of the mpyq.js library went AWOL. Although I pull requested the original library the PR has gone without a response for a while and I can no longer wait for a published version of it to be available.  

You can find the fork here: https://github.com/nexus-devtools/empeeku (I apologize in advance for the stupid name). This PR points heroprotocol.js to the new fork.
