### PR TITLE
Made sure storm-replay is available before we try to use it.

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ const openArchive = function (file, noCache) {
 // ensure non-breaking changes
 exports.get = (file, archive) => {
   log.debug('get() : ' + file + ', ' + archive);
-  if (['darwin', 'linux'].indexOf(process.platform) > -1) {
+  if (storm && ['darwin', 'linux'].indexOf(process.platform) > -1) {
     return exports.extractFile(file, archive)
   } else {
     return exports.extractFileJS(file, archive)

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ const openArchive = function (file, noCache) {
 // ensure non-breaking changes
 exports.get = (file, archive) => {
   log.debug('get() : ' + file + ', ' + archive);
-  if (storm && ['darwin', 'linux'].indexOf(process.platform) > -1) {
+  if (storm) {
     return exports.extractFile(file, archive)
   } else {
     return exports.extractFileJS(file, archive)


### PR DESCRIPTION
This makes sure we don't try to use storm-replay if it's not available.  I believe this fixes a problem where a parse on MacOS or Linux would fail if the storm-replay dependency has not been installed.

You could probably drop the OS check and just check for storm, but I don't know what the expectations are on Windows, so I left it alone.